### PR TITLE
ML NET - RZ#3515 Nie da się uruchomić serwera Z39.50 na Javie 8

### DIFF
--- a/knowledgeintegration-jzkit/pom.xml
+++ b/knowledgeintegration-jzkit/pom.xml
@@ -133,7 +133,7 @@
 		<repository>
 			<id>k-int</id>
 			<name>k-int maven2 repository</name>
-			<url>http://nexus.k-int.com/content/repositories/releases</url>
+			<url>https://maven.k-int.com/content/repositories/releases/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -373,12 +373,12 @@
 		<repository>
 			<id>k-int-releases</id>
 			<name>Knowledge Intergation Maven2 Repository</name>
-			<url>dav:http://nexus.k-int.com/content/repositories/releases/</url>
+			<url>dav:https://maven.k-int.com/content/repositories/releases/</url>
 		</repository>
 		<snapshotRepository>
 			<id>k-int-snapshots</id>
 			<name>Knowledge Intergation Maven2 Snapshot Repository</name>
-			<url>dav:http://nexus.k-int.com/content/repositories/snapshots</url>
+			<url>dav:https://maven.k-int.com/content/repositories/snapshots/</url>
 		</snapshotRepository>
 	</distributionManagement>
 

--- a/z3950-server-webapp/pom.xml
+++ b/z3950-server-webapp/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.jzkit</groupId>
 			<artifactId>jzkit_z3950_server</artifactId>
-			<version>3.0.1-SNAPSHOT</version>
+			<version>3.0.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>marc4j</groupId> 


### PR DESCRIPTION
Changed repo urls to https and jzkit_z3950_server version to available